### PR TITLE
Adds C methods that take a cv::Mat*

### DIFF
--- a/cscore-jni.def
+++ b/cscore-jni.def
@@ -64,6 +64,8 @@ CS_ReleaseEnumeratedSinks @61
 CS_FreeString @62
 CS_FreeEnumPropertyChoices @63
 CS_FreeEnumeratedProperties @64
+CS_GrabSinkFrameCpp @65
+CS_PutSourceFrameCpp @66
 
 ; JNI functions
 JNI_OnLoad

--- a/cscore.def
+++ b/cscore.def
@@ -64,3 +64,5 @@ CS_ReleaseEnumeratedSinks @61
 CS_FreeString @62
 CS_FreeEnumPropertyChoices @63
 CS_FreeEnumeratedProperties @64
+CS_GrabSinkFrameCpp @65
+CS_PutSourceFrameCpp @66

--- a/include/cscore_cpp.h
+++ b/include/cscore_cpp.h
@@ -294,4 +294,10 @@ std::vector<std::string> GetNetworkInterfaces();
 
 }  // namespace cs
 
+// C functions taking a cv::Mat* for specific interop implementations
+extern "C" {
+uint64_t CS_GrabSinkFrameCpp(CS_Sink sink, cv::Mat* image, CS_Status* status);
+void CS_PutSourceFrameCpp(CS_Source source, cv::Mat* image, CS_Status* status);
+}
+
 #endif  // CSCORE_CPP_H_

--- a/src/CvSinkImpl.cpp
+++ b/src/CvSinkImpl.cpp
@@ -185,6 +185,10 @@ uint64_t CS_GrabSinkFrame(CS_Sink sink, struct CvMat* image,
   return cs::GrabSinkFrame(sink, mat, status);
 }
 
+uint64_t CS_GrabSinkFrameCpp(CS_Sink sink, cv::Mat* image, CS_Status* status) {
+   return cs::GrabSinkFrame(sink, *image, status);
+}
+
 char* CS_GetSinkError(CS_Sink sink, CS_Status* status) {
   llvm::SmallString<128> buf;
   auto str = cs::GetSinkError(sink, buf, status);

--- a/src/CvSourceImpl.cpp
+++ b/src/CvSourceImpl.cpp
@@ -298,6 +298,11 @@ void CS_PutSourceFrame(CS_Source source, struct CvMat* image,
   return cs::PutSourceFrame(source, mat, status);
 }
 
+void CS_PutSourceFrameCpp(CS_Source source, cv::Mat* image, 
+                          CS_Status* status) {
+  return cs::PutSourceFrame(source, *image, status);
+}
+
 void CS_NotifySourceError(CS_Source source, const char* msg,
                           CS_Status* status) {
   return cs::NotifySourceError(source, msg, status);


### PR DESCRIPTION
Some implementations of OpenCV use cv::Mat as their native pointer
rather then CvMat, so we need to support both in the C interface