### PR TITLE
Adds support for building separate armhf artifacts

### DIFF
--- a/cscore.gradle
+++ b/cscore.gradle
@@ -178,7 +178,12 @@ def cscoreZipTask = { project ->
         group = 'WPILib'
         destinationDir = project.buildDir
         baseName = 'cscore'
-        classifier = "${project.buildPlatform}"
+        if (project.isArm && project.hasProperty('compilerPrefix')
+            && project.hasProperty('armSuffix')) {
+            classifier = "${project.buildPlatform}${project.armSuffix}"
+        } else {
+            classifier = "${project.buildPlatform}"
+        }
         duplicatesStrategy = 'exclude'
 
         from(file('include')) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,7 +8,13 @@ ext.useWpiUtil = { project ->
         def wpiUtil
 
         doFirst {
-            def wpiUtilDependency = project.dependencies.create("edu.wpi.first.wpilib:wpiutil:+:${project.isArm ? 'arm' : 'desktop'}@zip")
+            def wpiUtilDependency
+            if (project.isArm && project.hasProperty('compilerPrefix') && project.hasProperty('armSuffix')) {
+                wpiUtilDependency = project.dependencies.create("edu.wpi.first.wpilib:wpiutil:+:arm${project.armSuffix}@zip")
+            } else {
+                wpiUtilDependency = project.dependencies.create("edu.wpi.first.wpilib:wpiutil:+:${project.isArm ? 'arm' : 'desktop'}@zip")
+            }
+             
             def wpiUtilConfig = project.configurations.detachedConfiguration(wpiUtilDependency)
             wpiUtilConfig.setTransitive(false)
             wpiUtil = wpiUtilConfig.files[0].canonicalFile
@@ -59,7 +65,9 @@ ext.useWpiUtil = { project ->
 }
 
 ext.getOpenCvPlatformPackage = { targetPlatform ->
-    if (targetPlatform.architecture.arm) {
+    if (targetPlatform.architecture.arm && project.hasProperty('compilerPrefix') && project.hasProperty('armSuffix')) {
+        return "linux-arm${project.armSuffix}"
+    } else if (targetPlatform.architecture.arm) {
         return 'linux-arm'
     } else if (targetPlatform.operatingSystem.linux) {
         if (targetPlatform.architecture.amd64) {


### PR DESCRIPTION
Currently if using a separate compiler prefix, it would get published to
the arm classifier. This modifies so there is now an armhf classifier
that is used if a separate compiler prefix is used.

Dependent on equivelent PRs in ntcore (#177) and opencv (tbd)