### PR TITLE
Add CS_Destroy to force cleanup

### DIFF
--- a/src/main/native/cpp/cscore_c.cpp
+++ b/src/main/native/cpp/cscore_c.cpp
@@ -16,6 +16,11 @@
 #include "c_util.h"
 #include "cscore_cpp.h"
 
+#include "NetworkListener.h"
+#include "Notifier.h"
+
+#include "Log.h"
+
 extern "C" {
 
 CS_PropertyKind CS_GetPropertyKind(CS_Property property, CS_Status* status) {
@@ -373,6 +378,20 @@ void CS_FreeNetworkInterfaces(char** interfaces, int count) {
   if (!interfaces) return;
   for (int i = 0; i < count; ++i) std::free(interfaces[i]);
   std::free(interfaces);
+}
+
+// destroy all cscore internal state
+void CS_Destroy() {
+  try {
+    cs::Notifier::GetInstance().Stop();
+  } catch(const std::exception& e) {
+    ERROR("Notifier shutdown failed: " << e.what());
+  }
+  try {
+    cs::NetworkListener::GetInstance().Stop();
+  } catch(const std::exception& e) {
+    ERROR("NetworkListener shutdown failed: " << e.what());
+  }
 }
 
 }  // extern "C"

--- a/src/main/native/include/cscore_c.h
+++ b/src/main/native/include/cscore_c.h
@@ -376,6 +376,9 @@ char* CS_GetHostname();
 char** CS_GetNetworkInterfaces(int* count);
 void CS_FreeNetworkInterfaces(char** interfaces, int count);
 
+// don't call this
+void CS_Destroy();
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
I think this still fails on OSX, but it works on Linux, so good enough for now.