### PR TITLE
Update for wpi::Now() change to microseconds.

### DIFF
--- a/src/main/java/edu/wpi/cscore/CvSink.java
+++ b/src/main/java/edu/wpi/cscore/CvSink.java
@@ -60,7 +60,7 @@ public class CvSink extends VideoSink {
    * Times out (returning 0) after timeout seconds.
    * The provided image will have three 3-bit channels stored in BGR order.
    * @return Frame time, or 0 on error (call GetError() to obtain the error
-   *         message)
+   *         message); the frame time is in 1 us increments.
    */
   public long grabFrame(Mat image, double timeout) {
     return CameraServerJNI.grabSinkFrameTimeout(m_handle, image.nativeObj, timeout);
@@ -70,7 +70,7 @@ public class CvSink extends VideoSink {
    * Wait for the next frame and get the image.  May block forever.
    * The provided image will have three 3-bit channels stored in BGR order.
    * @return Frame time, or 0 on error (call GetError() to obtain the error
-   *         message)
+   *         message); the frame time is in 1 us increments.
    */
   public long grabFrameNoTimeout(Mat image) {
     return CameraServerJNI.grabSinkFrame(m_handle, image.nativeObj);

--- a/src/main/java/edu/wpi/cscore/VideoSource.java
+++ b/src/main/java/edu/wpi/cscore/VideoSource.java
@@ -90,6 +90,7 @@ public class VideoSource {
 
   /**
    * Get the last time a frame was captured.
+   * @return Time in 1 us increments.
    */
   public long getLastFrameTime() {
     return CameraServerJNI.getSourceLastFrameTime(m_handle);

--- a/src/main/native/cpp/MjpegServerImpl.cpp
+++ b/src/main/native/cpp/MjpegServerImpl.cpp
@@ -655,7 +655,7 @@ void MjpegServerImpl::ConnThread::SendStream(wpi::raw_socket_ostream& os) {
     // print the individual mimetype and the length
     // sending the content-length fixes random stream disruption observed
     // with firefox
-    double timestamp = frame.GetTime() / 10000000.0;
+    double timestamp = frame.GetTime() / 1000000.0;
     header.clear();
     oss << "\r\n--" BOUNDARY "\r\n"
         << "Content-Type: image/jpeg\r\n"

--- a/src/main/native/include/cscore_oo.h
+++ b/src/main/native/include/cscore_oo.h
@@ -122,6 +122,8 @@ class VideoSource {
   std::string GetDescription() const;
 
   /// Get the last time a frame was captured.
+  /// This uses the same time base as wpi::Now().
+  /// @return Time in 1 us increments.
   uint64_t GetLastFrameTime() const;
 
   /// Is the source currently connected to whatever is providing the images?
@@ -578,13 +580,15 @@ class CvSink : public VideoSink {
   /// Times out (returning 0) after timeout seconds.
   /// The provided image will have three 8-bit channels stored in BGR order.
   /// @return Frame time, or 0 on error (call GetError() to obtain the error
-  ///         message);
+  ///         message); the frame time is in the same time base as wpi::Now(),
+  ///         and is in 1 us increments.
   uint64_t GrabFrame(cv::Mat& image, double timeout = 0.225) const;
 
   /// Wait for the next frame and get the image.  May block forever.
   /// The provided image will have three 8-bit channels stored in BGR order.
   /// @return Frame time, or 0 on error (call GetError() to obtain the error
-  ///         message);
+  ///         message); the frame time is in the same time base as wpi::Now(),
+  ///         and is in 1 us increments.
   uint64_t GrabFrameNoTimeout(cv::Mat& image) const;
 
   /// Get error string.  Call this if WaitForFrame() returns 0 to determine


### PR DESCRIPTION
Also be explicit in docs about what timebase and step are used.