### PR TITLE
HttpCamera: Force reconnect when SetUrls() is called.

### DIFF
--- a/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/src/main/native/cpp/HttpCameraImpl.cpp
@@ -319,6 +319,7 @@ bool HttpCameraImpl::SetUrls(llvm::ArrayRef<std::string> urls,
   std::lock_guard<wpi::mutex> lock(m_mutex);
   m_locations.swap(locations);
   m_nextLocation = 0;
+  m_streamSettingsUpdated = true;
   return true;
 }
 


### PR DESCRIPTION
The URL often contains other information like the camera resolution,
not to mention actually changing cameras!